### PR TITLE
add post steps & post delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ mongod --dbpath <PATH>
 ```
 PATH EXAMPLE: /Users/leander/Desktop/Agile-Web/db
 
+Start Mongodb on Mac: 
+
+```
+sudo mongod --dbpath /System/Volumes/Data/data/db
+```
+
+[Icon-Set](https://www.streamlinehq.com/icons/streamline-mini-line)
+
 Run dummyData file by entering 
 ```
 node dummyData.js

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -1,36 +1,49 @@
-const Post = require("../models/post")
+const Post = require("../models/post");
 
 exports.postPage = (req, res) => {
     let postId = req.params.postId;
     Post.findById(postId).exec()
-    .then(post => {
-        res.render("post.ejs", { post: post });
-    }).catch(error => {
+        .then(post => {
+            res.render("post.ejs", {post: post});
+        }).catch(error => {
         console.log(error.message);
-        res.render("error.ejs");;
+        res.render("error.ejs");
     });
 }
 exports.createPostPage = (req, res) => {
     res.render("create_post.ejs");
 };
-exports.savePost = (req, res) => {
-    console.log(req.body)
+exports.savePost = (req, res, next) => {
+    let stepsArray = JSON.parse(req.body.steps);
     Post.create(
-    {
-        img: req.body.img,
-        title: req.body.title,
-        description: req.body.description
-    })
-    .then(post => {
-        console.log("rendering with postid" + post._id)
-        res.redirect(`/post/${post._id}`);    
-    });
+        {
+            img: req.body.img,
+            title: req.body.title,
+            description: req.body.description,
+            steps: stepsArray,
+        })
+        .then(post => {
+            console.log("Created and rendered post of id: " + post._id)
+            res.redirect(`/post/${post._id}`);
+        })
+        .catch(error => {
+            console.log(`Error creating post!\n${error.message}`);
+            next();
+        })
 };
 exports.editPostPage = (req, res) => {
     let postId = req.params.postId;
     res.send(`This is the page to edit the post of id: ${postId}`);
 };
-exports.deletePostPage = (req, res) => {
+exports.deletePostPage = (req, res, next) => {
     let postId = req.params.postId;
-    res.send(`This is the page to delete the post of id : ${postId}`);
+    Post.findByIdAndDelete(postId)
+        .then(() => {
+            res.redirect(`/`)
+        })
+        .catch(error => {
+            console.log(`Error deleting post by ID: ${postId}\n${error.message}`);
+            next();
+        });
+    console.log("deleted Post: " + postId);
 };

--- a/main.js
+++ b/main.js
@@ -3,7 +3,6 @@ const layouts = require("express-ejs-layouts")
 const port = 3000, express = require("express"), app = express();
 const path = require("path")
 const errorController = require("./controllers/errorController")
-const Post = require("./models/post")
 const bodyParser = require('body-parser');
 
 const mongoose = require("mongoose");
@@ -28,6 +27,10 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use(errorController.pageNotFoundError);
 app.use(errorController.internalServerError);
 
+const methodOverride = require("method-override");
+router.use(methodOverride("_method", {
+
+}));
 
 app.listen(port, () => {
  console.log(`The Express.js server has started and is listening on port number: ${port}`);

--- a/models/post.js
+++ b/models/post.js
@@ -1,7 +1,12 @@
 const mongoose = require("mongoose"),
- postSchema = mongoose.Schema({
-    title: String,
-    description: String,
-    img: String,
- });
+    stepSchema = mongoose.Schema({
+        number: String,
+        description: String,
+    }),
+    postSchema = mongoose.Schema({
+        title: String,
+        description: String,
+        img: String,
+        steps: [stepSchema],
+    });
 module.exports = mongoose.model("Post", postSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "express": "^4.18.2",
         "express-ejs-layouts": "^2.5.1",
         "http-status-codes": "^2.2.0",
+        "method-override": "^3.0.0",
         "mongoose": "^7.1.0"
       }
     },
@@ -553,6 +554,28 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+    },
+    "node_modules/method-override": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-3.0.0.tgz",
+      "integrity": "sha512-IJ2NNN/mSl9w3kzWB92rcdHpz+HjkxhDJWNDBqSlas+zQdP8wBiJzITPg08M/k2uVvMow7Sk41atndNtt/PHSA==",
+      "dependencies": {
+        "debug": "3.1.0",
+        "methods": "~1.1.2",
+        "parseurl": "~1.3.2",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/method-override/node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
     },
     "node_modules/methods": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "express": "^4.18.2",
     "express-ejs-layouts": "^2.5.1",
     "http-status-codes": "^2.2.0",
+    "method-override": "^3.0.0",
     "mongoose": "^7.1.0"
   }
 }

--- a/public/css/createPost.css
+++ b/public/css/createPost.css
@@ -1,6 +1,6 @@
 .formContainer {
     max-width: 800px;
-    margin: auto;
+    margin: auto auto 30px;
     padding: 15px;
     box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.15);
     border-radius: 20px;
@@ -8,6 +8,14 @@
 }
 
 #createPostForm {
+    margin-bottom: 0;
+}
+
+textarea {
+    resize: vertical;
+}
+
+#formGrid {
     width: 100%;
     display: grid;
     grid-gap: 15px;
@@ -42,7 +50,55 @@
     outline: none;
 }
 
-#submit {
+.icon {
+    width: 20px;
+    height: 20px;
+}
+
+.icon:hover {
+    background-color: #e0e0e0;
+}
+
+#stepsHeader {
+    grid-column: 1 / 3;
+}
+
+#addRemove {
+    height: fit-content;
+    display: flex;
+    gap: 5px;
+    justify-content: end;
+}
+
+#bottomButtonContainer {
+    display: flex;
+    justify-content: space-between;
+}
+
+#addRemove div {
+    border: none;
+    background-color: white;
+    margin: 0;
+    padding: 8px;
+    border-radius: 20px;
+}
+
+#stepsContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    margin-bottom: 15px;
+}
+
+.stepDescription {
+    height: 150px;
+}
+
+#addRemove div:hover {
+    background-color: #e0e0e0;
+}
+
+#submitButton {
     font-size: 16px;
     padding: 8px 15px 5px 15px;
     border-radius: 20px;
@@ -55,11 +111,15 @@
 }
 
 @media screen and (max-width: 800px) {
-    #createPostForm {
+    #formGrid {
         grid-template-columns: 1fr;
     }
 
     .inputGroup:nth-child(3) {
+        grid-column: 1 / 2;
+    }
+
+    #stepsHeader {
         grid-column: 1 / 2;
     }
 }

--- a/public/css/createPost.css
+++ b/public/css/createPost.css
@@ -106,7 +106,7 @@ textarea {
     background-color: #EAE34B;
 }
 
-#submit:hover {
+#submitButton:hover {
     box-shadow: 0 2px 8px 2px rgba(0, 0, 0, 0.15);
 }
 

--- a/public/css/post.css
+++ b/public/css/post.css
@@ -1,5 +1,130 @@
 .grid {
+    background-color: white;
+    border-radius: 20px;
+    box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.15);
+    max-width: 1000px;
+    margin: auto auto 30px;
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 30px;
+    grid-template-columns: 1fr 1fr 1fr;
+}
+
+.postButtons {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    align-items: center;
+}
+
+#username {
+    text-decoration: none;
+    color: black;
+}
+
+#followButton {
+    margin: 0;
+    padding: 5px 10px 5px 10px;
+    border-radius: 20px;
+    border: solid black 1px;
+    background-color: white;
+    cursor: pointer;
+}
+
+#followButton:hover {
+    background-color: #e0e0e0;
+}
+
+#deleteButton {
+    padding: 5px;
+    border-radius: 50px;
+    width: 25px;
+    height: 25px;
+    color: red;
+}
+
+#deleteButton:hover {
+    background-color: rgba(136, 136, 136, 0.15);
+}
+
+#postInfo {
+    grid-column: 1 / 3;
+    padding: 12px;
+}
+
+#postTitle {
+    margin: 0;
+    font-size: 26px;
+}
+
+#postDescription {
+    text-align: justify;
+    margin-bottom: 15px;
+}
+
+#postImage {
+    border-top-right-radius: 20px;
+    grid-column: 3 / 4;
+    width: 100%;
+}
+
+#stepsTitle {
+    margin: 0 0 0 12px;
+    font-size: 20px;
+    font-weight: bold;
+}
+
+#stepContainer {
+    grid-column: 1 / 4;
+}
+
+#stepInfo {
+    text-align: justify;
+    padding: 12px;
+}
+
+#stepNumber {
+    padding: 10px;
+    margin-bottom: 5px;
+    background-color: #cccccc;
+    border-radius: 20px;
+    font-weight: bold;
+    width: 20px;
+    text-align: center;
+    height: 20px;
+}
+
+@media screen and (max-width: 800px) {
+    .grid {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    #postInfo {
+        grid-column: 1 / 2;
+    }
+
+    #postImage {
+        grid-column: 2 / 3;
+    }
+
+    #stepContainer {
+        grid-column: 1 / 3;
+    }
+}
+
+@media screen and (max-width: 540px) {
+    #postTitle {
+        font-size: 20px;
+    }
+
+    #postDescription {
+        font-size: 14px;
+    }
+
+    #stepNumber {
+        width: 18px;
+        height: 18px;
+    }
+
+    #stepContainer {
+        font-size: 14px;
+    }
 }

--- a/public/js/createPost.js
+++ b/public/js/createPost.js
@@ -1,0 +1,47 @@
+let count = 0;
+
+function addStep() {
+    count += 1;
+
+    const label = document.createElement("label");
+    label.for = "step" + count;
+    label.innerHTML = "Schritt: " + count;
+
+    const textarea = document.createElement("textarea");
+    textarea.className = "textInput stepDescription";
+    textarea.id = "step" + count;
+    textarea.name = "step" + count;
+    textarea.placeholder = "Erklärung für Schritt " + count + ". ...";
+
+    const div = document.createElement("div");
+    div.id = count;
+    div.className = "inputGroup";
+    document.getElementById("stepsContainer");
+    div.appendChild(label);
+    div.appendChild(textarea);
+
+    const container = document.getElementById("stepsContainer");
+    container.appendChild(div);
+}
+
+function removeStep() {
+    if (count > 1) {
+        let step = document.getElementById(count);
+        step.remove();
+        count -= 1;
+    }
+}
+
+let createPostForm = document.getElementById("createPostForm");
+createPostForm.addEventListener('formdata', (e) => {
+    const formData = e.formData;
+    let stepArray = [];
+    for (let i = 1; i <= count; i++) {
+        let input = document.getElementById("step" + i);
+        //delete data of input fields of each step
+        formData.delete("step" + i);
+        //rebuild step as JSON object
+        stepArray.push({number: i, description: input.value});
+    }
+    formData.append('steps', JSON.stringify(stepArray));
+});

--- a/router.js
+++ b/router.js
@@ -9,7 +9,6 @@ const router = express.Router();
 router.get('/test', (req, res, next) => {
     return res.status(200).json({
         data : "Service is running! "
-
     });
 })
 
@@ -31,7 +30,7 @@ router.delete('/creator/:creatorName', creatorController.deleteCreatorPage);
 router.get("/post/create", postController.createPostPage)
 router.post("/post/create", postController.savePost);
 router.get("/post/:postId", postController.postPage);
-router.patch("/post/:postId", postController.editPostPage);
-router.delete("/post/:postId", postController.deletePostPage);
+router.patch("/post/:postId/edit", postController.editPostPage);
+router.get("/post/:postId/delete", postController.deletePostPage);
 
 module.exports = router;

--- a/views/create_post.ejs
+++ b/views/create_post.ejs
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="/css/createPost.css">
+<script type="text/javascript" src="/js/createPost.js"></script>
 <body onload="addStep()">
 <div class="formContainer">
     <h1>Erstelle ein neues DIY</h1>
@@ -44,52 +45,3 @@
     </form>
 </div>
 </body>
-<script>
-    let count = 0;
-
-    function addStep() {
-        count += 1;
-
-        const label = document.createElement("label");
-        label.for = "step" + count;
-        label.innerHTML = "Schritt: " + count;
-
-        const textarea = document.createElement("textarea");
-        textarea.className = "textInput stepDescription";
-        textarea.id = "step" + count;
-        textarea.name = "step" + count;
-        textarea.placeholder = "Erklärung für Schritt " + count + ". ...";
-
-        const div = document.createElement("div");
-        div.id = count;
-        div.className = "inputGroup";
-        document.getElementById("stepsContainer");
-        div.appendChild(label);
-        div.appendChild(textarea);
-
-        const container = document.getElementById("stepsContainer");
-        container.appendChild(div);
-    }
-
-    function removeStep() {
-        if (count > 1) {
-            let step = document.getElementById(count);
-            step.remove();
-            count -= 1;
-        }
-    }
-
-    let createPostForm = document.getElementById("createPostForm");
-    createPostForm.addEventListener('formdata', (e) => {
-        const formData = e.formData;
-        let stepArray = [];
-        for (let i = 1; i <= count; i++) {
-            let input = document.getElementById("step" + i);
-            //delete data of input fields of each step
-            formData.delete("step" + i);
-            //rebuild step as JSON object
-            stepArray.push({number: i, description: input.value});
-        }
-        formData.append('steps', JSON.stringify(stepArray));
-    });
-</script>

--- a/views/create_post.ejs
+++ b/views/create_post.ejs
@@ -1,21 +1,95 @@
 <link rel="stylesheet" href="/css/createPost.css">
+<body onload="addStep()">
 <div class="formContainer">
     <h1>Erstelle ein neues DIY</h1>
-    <form id="createPostForm" action="/post/create" method="post">
-        <div class="inputGroup">
-            <label for="title">Titel</label>
-            <input id="title" class="textInput" type="text" name="title" placeholder="Titel..." required>
+    <form id="createPostForm" name="createPostForm" action="/post/create" method="POST">
+        <div id="formGrid">
+            <div class="inputGroup">
+                <label for="title">Titel</label>
+                <input id="title" class="textInput" type="text" name="title" placeholder="Titel..." required>
+            </div>
+            <div class="inputGroup">
+                <label for="img">Bild</label>
+                <input id="img" class="textInput" type="text" name="img" placeholder="https://bildaddresse" required>
+            </div>
+            <div class="inputGroup">
+                <label for="description">Kurze Beschreibung</label>
+                <textarea id="description" class="textInput" name="description" maxlength="250"
+                          placeholder="Eine kurze Beschreibung..." required></textarea>
+            </div>
         </div>
-        <div class="inputGroup">
-            <label for="img">Bild</label>
-            <input id="img" class="textInput" type="text" name="img" placeholder="https://bildaddresse" required>
+        <h2 id="stepsHeader">Anleitungsschritte</h2>
+        <div id="stepsContainer"></div>
+        <div id="bottomButtonContainer">
+            <div id="addRemove">
+                <div onclick="addStep()">
+                    <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14">
+                        <g>
+                            <line x1="7" y1="0.54" x2="7" y2="13.54" fill="none" stroke="#000000" stroke-linecap="round"
+                                  stroke-linejoin="round"></line>
+                            <line x1="0.5" y1="7" x2="13.5" y2="7" fill="none" stroke="#000000" stroke-linecap="round"
+                                  stroke-linejoin="round"></line>
+                        </g>
+                    </svg>
+                </div>
+                <div onclick="removeStep()">
+                    <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14">
+                        <line x1="0.5" y1="7" x2="13.5" y2="7" fill="none" stroke="#000000" stroke-linecap="round"
+                              stroke-linejoin="round"></line>
+                    </svg>
+                </div>
+            </div>
+            <input id="submitButton" type="submit" value="Hochladen">
         </div>
-        <div class="inputGroup">
-            <label for="description">Kurze Beschreibung</label>
-            <textarea id="description" class="textInput" name="description" maxlength="250" placeholder="Eine kurze Beschreibung..." required></textarea>
-        </div>
-        <div>
-            <input id="submit" type="submit" name="submit" value="Hochladen">
-        </div>
-   </form>
+    </form>
 </div>
+</body>
+<script>
+    let count = 0;
+
+    function addStep() {
+        count += 1;
+
+        const label = document.createElement("label");
+        label.for = "step" + count;
+        label.innerHTML = "Schritt: " + count;
+
+        const textarea = document.createElement("textarea");
+        textarea.className = "textInput stepDescription";
+        textarea.id = "step" + count;
+        textarea.name = "step" + count;
+        textarea.placeholder = "Erklärung für Schritt " + count + ". ...";
+
+        const div = document.createElement("div");
+        div.id = count;
+        div.className = "inputGroup";
+        document.getElementById("stepsContainer");
+        div.appendChild(label);
+        div.appendChild(textarea);
+
+        const container = document.getElementById("stepsContainer");
+        container.appendChild(div);
+    }
+
+    function removeStep() {
+        if (count > 1) {
+            let step = document.getElementById(count);
+            step.remove();
+            count -= 1;
+        }
+    }
+
+    let createPostForm = document.getElementById("createPostForm");
+    createPostForm.addEventListener('formdata', (e) => {
+        const formData = e.formData;
+        let stepArray = [];
+        for (let i = 1; i <= count; i++) {
+            let input = document.getElementById("step" + i);
+            //delete data of input fields of each step
+            formData.delete("step" + i);
+            //rebuild step as JSON object
+            stepArray.push({number: i, description: input.value});
+        }
+        formData.append('steps', JSON.stringify(stepArray));
+    });
+</script>

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -1,52 +1,30 @@
 <link rel="stylesheet" href="/css/post.css">
-<body>
-    <h1><%= post.title %></h1>
-    
-    <div class="grid">
-        <div> <%= post.description %></div>
-        <% if(post.img){ %>
-        <img class="image"
-            src=<%= post.img %>
-            width="350" height="300">
-        <% } %>
-        <!-- <div> 2. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
-            labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea
-            rebum.
-            Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
-            amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
-            erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
-            no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing
-            elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
-            vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est
-            Lorem ipsum dolor sit amet.
-
-            Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu
-            feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril
-            delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing
-            elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.</div>
-        <div>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore
-            et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
-            Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
-            amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
-            erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
-            no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing
-            elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
-            vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est
-            Lorem ipsum dolor sit amet.
-
-            Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu
-            feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril
-            delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing
-            elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.
-
-            Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea
-            commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat,
-            vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit
-            praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.
-
-            Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer
+<div class="grid">
+    <div id="postInfo">
+        <div class="postButtons">
+            <a href="/creator/Sönke" id="username">username</a>
+            <button id="followButton">Folgen</button>
         </div>
-        <img class="image" src="https://www.deutsche-papier.de/wp-content/uploads/bastelpapier.jpg" width="500"
-            height="400"> -->
+        <h1 id="postTitle"><%= post.title %></h1>
+        <div id="postDescription"> <%= post.description %></div>
+        <div class="postButtons">
+            <a id="deleteButton" href=<%=`/post/${post._id}/delete`%>>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14"><g><polyline points="11.5 5.5 10.5 13.5 3.5 13.5 2.5 5.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></polyline><line x1="1" y1="3.5" x2="13" y2="3.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line><path d="M4.46,3.21l0-1.73a1,1,0,0,1,1-1h3a1,1,0,0,1,1,1v2" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path></g></svg>
+            </a>
+        </div>
     </div>
-</body>
+    <% if(post.img){ %>
+        <img id="postImage" alt="Post Image" src=<%= post.img %>>
+    <% } %>
+        <% if(post.steps.length !== 0){ %>
+            <h2 id="stepsTitle">Anleitung</h2>
+            <% post.steps.forEach(step => { %>
+                <div id="stepContainer">
+                    <div id="stepInfo">
+                        <div id="stepNumber"><%= step.number %></div>
+                        <div><%= step.description %></div>
+                    </div>
+                </div>
+        <% })} %>
+</div>
+


### PR DESCRIPTION
Introducing Steps for Posts:

Through a flexible form you can now add steps to a post. Steps are stored as embedded documents of a post and contain a number and a description for now. Later we can easily expand them to carry photos or maybe videos.

![Bildschirmfoto 2023-05-14 um 17 36 03](https://github.com/LeanderAK/WTAT1_Group_B/assets/116285904/f32f6001-edb4-4afc-9ae3-31f100a8353b)

Posts then also display the posts steps on their respective page:

![Bildschirmfoto 2023-05-14 um 17 35 44](https://github.com/LeanderAK/WTAT1_Group_B/assets/116285904/997ed6a1-6a16-4ed4-b073-e966b0035dfd)

Additionally Posts are now deletable. I tried using method-override as presented in the book. However, with several tries and several solutions from the internet it would not want to work with the DELETE method, hence I left it as a get method for now. We might look for another solution to handle http methods (Axios?) in the future. 

Otherwise the reworked pages are of course also responsive, we just have to adjust the design for the images, once the steps have medias attached and displayed as well.